### PR TITLE
Install requests in github actions dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y libsasl2-dev
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install dbt-core==${DBT_VERSION} && \
     pip install dbt-bigquery && \
+    pip install requests && \
     pip install awscli
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Since it is needed in one of the github action steps in HyreAS/dbt-cloud

Don't know if this is better than installing it inline in the deploy script, but it feels a bit cleaner to not have to "keep monkey patching" the docker container.
Maybe what we should do is get these definitions (dockerfile + github action description) into the actual dbt-cloud repo?